### PR TITLE
Update for action version.

### DIFF
--- a/tests/src/test/scala/actionContainers/Ruby26ActionLoopContainerTests.scala
+++ b/tests/src/test/scala/actionContainers/Ruby26ActionLoopContainerTests.scala
@@ -65,6 +65,7 @@ class Ruby26ActionLoopContainerTests extends BasicActionRunnerTests with WskActo
        |       "api_key" => ENV['__OW_API_KEY'],
        |       "namespace" => ENV['__OW_NAMESPACE'],
        |       "action_name" => ENV['__OW_ACTION_NAME'],
+       |       "action_version" => ENV['__OW_ACTION_VERSION'],
        |       "activation_id" => ENV['__OW_ACTIVATION_ID'],
        |       "deadline" => ENV['__OW_DEADLINE']
        |  }


### PR DESCRIPTION
See https://github.com/apache/openwhisk/pull/4761.

Why do we have a loop and non loop version? Can't we reuse the one copy of this code?