### PR TITLE
flush output on init error and when writing log sentinels

### DIFF
--- a/core/ruby2.5Action/rackapp/init.rb
+++ b/core/ruby2.5Action/rackapp/init.rb
@@ -9,6 +9,7 @@ class InitApp
     # Make sure that this action is not initialised more than once
     if File.exist? CONFIG then
       puts "Error: Cannot initialize the action more than once."
+      STDOUT.flush
       return ErrorResponse.new 'Cannot initialize the action more than once.', 403
     end
 

--- a/core/ruby2.5Action/rackapp/middleware/sentinel_handler.rb
+++ b/core/ruby2.5Action/rackapp/middleware/sentinel_handler.rb
@@ -7,6 +7,8 @@ class SentinelHandler < MiddlewareBase
       puts response.body if response.status!=200
       puts "XXX_THE_END_OF_A_WHISK_ACTIVATION_XXX"
       warn "XXX_THE_END_OF_A_WHISK_ACTIVATION_XXX"
+      STDOUT.flush
+      STDERR.flush
     end
     response
   end


### PR DESCRIPTION
preserving non conflicting flush change from #33 