### PR TITLE
Fixes to v2.5 and v2.6 to get things working again

### DIFF
--- a/core/ruby2.5Action/Dockerfile
+++ b/core/ruby2.5Action/Dockerfile
@@ -20,7 +20,7 @@ FROM ruby:2.5
 RUN gem install \
         bundler \
         rubyzip \
-        rack \
+        rack:'~>2.0.0' \
         puma \
         rake          `#optional` \
         mechanize     `#optional` \

--- a/core/ruby2.5Action/Gemfile
+++ b/core/ruby2.5Action/Gemfile
@@ -1,4 +1,4 @@
 source 'https://rubygems.org'
 
-gem 'rack'
+gem 'rack' ~> 2.0.0
 gem 'rubyzip'

--- a/core/ruby2.6ActionLoop/Dockerfile
+++ b/core/ruby2.6ActionLoop/Dockerfile
@@ -28,7 +28,7 @@ RUN curl -sL \
   && cd openwhisk-runtime-go-*/main\
   && GO111MODULE=on go build -o /bin/proxy
 
-FROM ruby:2.6.2-alpine3.9
+FROM ruby:2.6
 
 # select the builder to use
 ARG GO_PROXY_BUILD_FROM=release
@@ -40,6 +40,5 @@ COPY --from=builder_release /bin/proxy /bin/proxy_release
 RUN mv /bin/proxy_${GO_PROXY_BUILD_FROM} /bin/proxy
 ADD lib/launcher.rb /proxy/lib/launcher.rb
 ADD bin/compile /proxy/bin/compile
-RUN apk update && apk add python3
 ENV OW_COMPILER=/proxy/bin/compile
 ENTRYPOINT ["/bin/proxy"]


### PR DESCRIPTION
version 2.1.0 of rack (released 26 days ago) breaks the ruby 2.5 action for openwhisk.  Avoid the problem by pinning the version of rack to 2.0.x. See #44 for details.

The actionloop goproxy executable fails to run in the ruby-2.6-alpine image, but works just fine in the debian based ruby-2.6 image. Since action-ruby-v2.5 is based on ruby-2.5 (and not ruby-2.5-alpine) it is expedient to use the same larger-style image for both ruby versions and
get the tests working again
