### PR TITLE
Install latest security fixes with every image build.

### DIFF
--- a/core/ruby2.5Action/CHANGELOG.md
+++ b/core/ruby2.5Action/CHANGELOG.md
@@ -19,6 +19,9 @@
 
 # Ruby 2.5 OpenWhisk Runtime Container
 
+## Next Release
+  - Install latest security fixes with every image build.
+
 ## 1.15.0
   - Build proxy using golang 1.15 and openwhisk-runtime-go 1.16.0 (#48)
 

--- a/core/ruby2.5Action/Dockerfile
+++ b/core/ruby2.5Action/Dockerfile
@@ -27,8 +27,16 @@ RUN gem install \
         activesupport `#optional` \
         jwt           `#optional`
 
-# create src directory to store action files
-RUN mkdir -p /action/src
+
+RUN \
+    apt-get -y update \
+    # Upgrade installed packages to get latest security fixes if the base image does not contain them already.
+    && apt-get upgrade -y --no-install-recommends \
+    # Cleanup apt data, we do not need them later on.
+    && rm -rf /var/lib/apt/lists/* \
+    # create src directory to store action files
+    && mkdir -p /action/src
+
 ADD rackapp /action/rackapp/
 COPY config.ru /action
 

--- a/core/ruby2.6ActionLoop/CHANGELOG.txt
+++ b/core/ruby2.6ActionLoop/CHANGELOG.txt
@@ -19,6 +19,9 @@
 
 # Ruby 2.6 OpenWhisk Runtime Container
 
+## Next Release
+  - Install latest security fixes with every image build.
+
 ## 1.15.0
   - Build proxy using golang 1.15 and openwhisk-runtime-go 1.16.0 (#48)
 

--- a/core/ruby2.6ActionLoop/Dockerfile
+++ b/core/ruby2.6ActionLoop/Dockerfile
@@ -33,7 +33,15 @@ FROM ruby:2.6
 # select the builder to use
 ARG GO_PROXY_BUILD_FROM=release
 
-RUN mkdir -p /proxy/bin /proxy/lib /proxy/action
+RUN \
+    apt-get -y update \
+    # Upgrade installed packages to get latest security fixes if the base image does not contain them already.
+    && apt-get upgrade -y --no-install-recommends \
+    # Cleanup apt data, we do not need them later on.
+    && rm -rf /var/lib/apt/lists/* \
+    # Create required directories
+    && mkdir -p /proxy/bin /proxy/lib /proxy/action
+
 WORKDIR /proxy
 COPY --from=builder_source /bin/proxy /bin/proxy_source
 COPY --from=builder_release /bin/proxy /bin/proxy_release


### PR DESCRIPTION
* Add `apt-get upgrade` to always install latest security fixes during every image build.
  This is done to always have an up to date image even when the base image is not updated for some reason.
* Cleanup apt data once they are not required anymore.