### PR TITLE
Update travis build vm dist form xenial to focal 

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -16,8 +16,8 @@
 #
 
 sudo: required
-dist: xenial
-jdk: openjdk8
+dist: focal
+jdk: openjdk11
 language: java
 
 services:

--- a/.travis.yml
+++ b/.travis.yml
@@ -25,8 +25,10 @@ services:
 # required to support multi-stage build
 addons:
   apt:
+    sources:
+     - sourcelist: 'deb https://download.docker.com/linux/ubuntu $(lsb_release -cs) stable'
     packages:
-      - docker-ce
+     - docker-ce
 
 before_install:
   - "cat /etc/os-release"


### PR DESCRIPTION
This bings the machines to the build VM to a more up to date Ubuntu version which should also reduce the risk of loosing support for the version and use openjdk11